### PR TITLE
Add Treasurer field to CashRegister with export refactoring

### DIFF
--- a/ClubTreasury.ComponentTests/Components/CashRegisterDialogTests.cs
+++ b/ClubTreasury.ComponentTests/Components/CashRegisterDialogTests.cs
@@ -8,6 +8,7 @@ using MudBlazor.Services;
 using ClubTreasury.Data.CashRegister;
 using ClubTreasury.Data.Notification;
 using ClubTreasury.Data.OperationResult;
+using ClubTreasury.Data.Person;
 
 namespace ClubTreasury.ComponentTests.Components;
 
@@ -17,6 +18,7 @@ public class CashRegisterDialogTests : BunitContext
 {
     private ICashRegisterService _cashRegisterService = null!;
     private ICashRegisterLogoService _cashRegisterLogoService = null!;
+    private IPersonService _personService = null!;
     private IStringLocalizer<Translation> _localizer = null!;
     private INotificationService _notificationService = null!;
     private IResultFactory _resultFactory = null!;
@@ -26,9 +28,17 @@ public class CashRegisterDialogTests : BunitContext
     {
         Services.AddSingleton(_cashRegisterService = A.Fake<ICashRegisterService>());
         Services.AddSingleton(_cashRegisterLogoService = A.Fake<ICashRegisterLogoService>());
+        Services.AddSingleton(_personService = A.Fake<IPersonService>());
         Services.AddSingleton(_localizer = A.Fake<IStringLocalizer<Translation>>());
         Services.AddSingleton(_notificationService = A.Fake<INotificationService>());
         Services.AddSingleton(_resultFactory = A.Fake<IResultFactory>());
+
+        A.CallTo(() => _personService.GetAllPersonsAsync(A<CancellationToken>._))
+            .Returns(new List<PersonModel>
+            {
+                new() { Id = 1, Name = "John Doe" },
+                new() { Id = 2, Name = "Jane Smith" }
+            });
 
         A.CallTo(() => _localizer[A<string>._])
             .ReturnsLazily((string key) => new LocalizedString(key, key));

--- a/ClubTreasury.Tests/Services/CashRegisterServiceTests.cs
+++ b/ClubTreasury.Tests/Services/CashRegisterServiceTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using ClubTreasury.Data;
 using ClubTreasury.Data.CashRegister;
 using ClubTreasury.Data.OperationResult;
+using ClubTreasury.Data.Person;
 
 namespace ClubTreasury.Tests.Services;
 
@@ -165,6 +166,58 @@ public class CashRegisterServiceTests
         // Assert
         result.Should().ContainKey(registerWithTx.Id);
         result.Should().NotContainKey(registerEmpty.Id);
+    }
+
+    #endregion
+
+    #region GetCashRegisterWithTreasurerAsync Tests
+
+    [Test]
+    public async Task GetCashRegisterWithTreasurer_WhenExists_ShouldReturnWithTreasurer()
+    {
+        // Arrange
+        var person = new PersonModel { Name = "John Doe" };
+        await _context.Persons.AddAsync(person);
+        await _context.SaveChangesAsync();
+
+        var cashRegister = new CashRegisterModel { Name = "Test Register", TreasurerId = person.Id };
+        await _context.CashRegisters.AddAsync(cashRegister);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetCashRegisterWithTreasurerAsync(cashRegister.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test Register");
+        result.Treasurer.Should().NotBeNull();
+        result.Treasurer!.Name.Should().Be("John Doe");
+    }
+
+    [Test]
+    public async Task GetCashRegisterWithTreasurer_WhenNoTreasurer_ShouldReturnWithNullTreasurer()
+    {
+        // Arrange
+        var cashRegister = new CashRegisterModel { Name = "No Treasurer Register" };
+        await _context.CashRegisters.AddAsync(cashRegister);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetCashRegisterWithTreasurerAsync(cashRegister.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Treasurer.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetCashRegisterWithTreasurer_WhenNotFound_ShouldReturnNull()
+    {
+        // Act
+        var result = await _sut.GetCashRegisterWithTreasurerAsync(999);
+
+        // Assert
+        result.Should().BeNull();
     }
 
     #endregion

--- a/ClubTreasury.Tests/Services/ExportServiceTests.cs
+++ b/ClubTreasury.Tests/Services/ExportServiceTests.cs
@@ -46,7 +46,7 @@ public class ExportServiceTests
         _testExportPath = Path.Combine(Path.GetTempPath(), $"ExportTest_{Guid.NewGuid()}");
         Directory.CreateDirectory(_testExportPath);
         A.CallTo(() => _exportPathProvider.ExportPath)
-            .Returns(_testExportPath);  
+            .Returns(_testExportPath);
 
         A.CallTo(() => _localizer["NoData"])
             .Returns(new LocalizedString("NoData", "No data available"));
@@ -92,6 +92,7 @@ public class ExportServiceTests
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
         const string filename = "test_export.csv";
+        var options = new ExportOptions(begin, end, filename, 1);
 
         var transactions = new List<TransactionModel>
         {
@@ -108,7 +109,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportTransactionsToCsvAsync(begin, end, filename, 1);
+        var result = await _sut.ExportTransactionsToCsvAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -128,6 +129,7 @@ public class ExportServiceTests
     {
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
+        var options = new ExportOptions(begin, end, "empty.csv", 1);
 
         A.CallTo(() => _transactionService.GetTransactionsForExportAsync(begin, end, 1))
             .Returns(new List<TransactionModel>());
@@ -137,7 +139,7 @@ public class ExportServiceTests
         A.CallTo(() => _resultFactory.ExportFailed(A<string>._))
             .Returns(failed);
 
-        var result = await _sut.ExportTransactionsToCsvAsync(begin, end, "empty.csv", 1);
+        var result = await _sut.ExportTransactionsToCsvAsync(options);
 
         result.Should().Be(failed);
     }
@@ -148,7 +150,7 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "error_export.csv";
+        var options = new ExportOptions(begin, end, "error_export.csv", 1);
 
         A.CallTo(() => _transactionService.GetTransactionsForExportAsync(begin, end, 1))
             .Throws(new Exception("Database error"));
@@ -158,7 +160,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportTransactionsToCsvAsync(begin, end, filename, 1);
+        var result = await _sut.ExportTransactionsToCsvAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -174,8 +176,8 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "test_export.pdf";
-        var cancellationToken = CancellationToken.None;
+        const string filename = "test_export.pdf";
+        var options = new PdfExportOptions(begin, end, filename, 1, "Test Register", "John Doe");
 
         var transactions = new List<TransactionModel>
         {
@@ -190,12 +192,14 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportTransactionsToPdfAsync(begin, end, filename, 1, "Test Register", cancellationToken);
+        var result = await _sut.ExportTransactionsToPdfAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
         A.CallTo(() => _pdfRenderer.RenderTransactionPdfExportAsync(
-            transactions, begin, end, A<string>._, "Test Register", A<byte[]?>._, A<string?>._, cancellationToken))
+            transactions, A<PdfRenderOptions>.That.Matches(r =>
+                r.CashRegisterName == "Test Register" && r.TreasurerName == "John Doe"),
+            A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -205,14 +209,14 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "canceled_export.pdf";
+        var options = new PdfExportOptions(begin, end, "canceled_export.pdf", 1, "Test Register", "John Doe");
         var cancellationToken = new CancellationToken(canceled: true);
 
         A.CallTo(() => _transactionService.GetTransactionsForBudgetExportAsync(begin, end, 1))
             .Returns(new List<TransactionModel>());
 
         A.CallTo(() => _pdfRenderer.RenderTransactionPdfExportAsync(
-                A<IEnumerable<TransactionModel>>._, begin, end, A<string>._, A<string>._, A<byte[]?>._, A<string?>._, cancellationToken))
+                A<IEnumerable<TransactionModel>>._, A<PdfRenderOptions>._, cancellationToken))
             .Throws(new OperationCanceledException());
 
         var expectedResult = Result.Failure(Error.Canceled with { Message = "Canceled" });
@@ -220,7 +224,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportTransactionsToPdfAsync(begin, end, filename, 1, "Test Register", cancellationToken);
+        var result = await _sut.ExportTransactionsToPdfAsync(options, cancellationToken);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -232,8 +236,7 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "error_export.pdf";
-        var cancellationToken = CancellationToken.None;
+        var options = new PdfExportOptions(begin, end, "error_export.pdf", 1, "Test Register", "John Doe");
 
         A.CallTo(() => _transactionService.GetTransactionsForExportAsync(begin, end, 1))
             .Throws(new Exception("Render error"));
@@ -243,7 +246,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportTransactionsToPdfAsync(begin, end, filename, 1, "Test Register", cancellationToken);
+        var result = await _sut.ExportTransactionsToPdfAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -259,7 +262,8 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "budget_export.csv";
+        const string filename = "budget_export.csv";
+        var options = new ExportOptions(begin, end, filename, 1);
 
         var transactions = new List<TransactionModel>
         {
@@ -280,7 +284,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportBudgetToCsvAsync(begin, end, filename, 1);
+        var result = await _sut.ExportBudgetToCsvAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -294,7 +298,7 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "error_budget.csv";
+        var options = new ExportOptions(begin, end, "error_budget.csv", 1);
 
         A.CallTo(() => _transactionService.GetTransactionsForBudgetExportAsync(begin, end, 1))
             .Throws(new Exception("Database error"));
@@ -304,7 +308,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportBudgetToCsvAsync(begin, end, filename, 1);
+        var result = await _sut.ExportBudgetToCsvAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -320,7 +324,8 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "budget_export.xlsx";
+        const string filename = "budget_export.xlsx";
+        var options = new ExportOptions(begin, end, filename, 1);
 
         var transactions = new List<TransactionModel>
         {
@@ -341,7 +346,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportBudgetToExcelAsync(begin, end, filename, 1);
+        var result = await _sut.ExportBudgetToExcelAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);
@@ -355,7 +360,7 @@ public class ExportServiceTests
         // Arrange
         var begin = new DateTime(2024, 1, 1);
         var end = new DateTime(2024, 1, 31);
-        var filename = "error_budget.xlsx";
+        var options = new ExportOptions(begin, end, "error_budget.xlsx", 1);
 
         A.CallTo(() => _transactionService.GetTransactionsForBudgetExportAsync(begin, end, 1))
             .Throws(new Exception("Database error"));
@@ -365,7 +370,7 @@ public class ExportServiceTests
             .Returns(expectedResult);
 
         // Act
-        var result = await _sut.ExportBudgetToExcelAsync(begin, end, filename, 1);
+        var result = await _sut.ExportBudgetToExcelAsync(options);
 
         // Assert
         result.Should().Be(expectedResult);

--- a/Data/CashDataContext.cs
+++ b/Data/CashDataContext.cs
@@ -77,6 +77,12 @@ namespace ClubTreasury.Data
                 .IsUnique();
 
             modelBuilder.Entity<CashRegisterModel>()
+                .HasOne(cr => cr.Treasurer)
+                .WithMany()
+                .HasForeignKey(cr => cr.TreasurerId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<CashRegisterModel>()
                 .HasOne(cr => cr.Logo)
                 .WithOne(l => l.CashRegister)
                 .HasForeignKey<CashRegisterLogoModel>(l => l.CashRegisterId)

--- a/Data/CashRegister/CashRegisterDialog.razor
+++ b/Data/CashRegister/CashRegisterDialog.razor
@@ -3,7 +3,9 @@
 @using Microsoft.Extensions.Localization
 @using ClubTreasury.Data.Notification
 @using ClubTreasury.Data.OperationResult
+@using ClubTreasury.Data.Person
 @inject ICashRegisterService CashRegisterService
+@inject IPersonService PersonService
 @inject ICashRegisterLogoService CashRegisterLogoService
 @inject IStringLocalizer<Translation> Localizer
 @inject INotificationService NotificationService
@@ -24,6 +26,15 @@
                     <MudSelectItem T="int" Value="@month">
                         @DateTimeFormatInfo.CurrentInfo.GetMonthName(month)
                     </MudSelectItem>
+                }
+            </MudSelect>
+
+            <MudSelect T="int?" Label="@Localizer["Treasurer"]" @bind-Value="_cashRegisterModel.TreasurerId"
+                       Clearable="true"
+                       ToStringFunc="@TreasurerIdToName">
+                @foreach (var p in _persons)
+                {
+                    <MudSelectItem T="int?" Value="@p.Id">@p.Name</MudSelectItem>
                 }
             </MudSelect>
         </MudForm>
@@ -73,12 +84,14 @@
     private string? _existingLogoDataUri;
     private IBrowserFile? _pendingFile;
     private bool _logoRemoved;
+    private IEnumerable<PersonModel> _persons = [];
 
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
 
     protected override async Task OnInitializedAsync()
     {
         _isEditMode = CashRegisterId.HasValue;
+        _persons = await PersonService.GetAllPersonsAsync();
         await MudDialog.SetTitleAsync(_isEditMode ? Localizer["Edit"] : Localizer["AddEntry"]);
         await LoadCashRegisterAsync();
     }
@@ -147,4 +160,7 @@
     }
 
     private void Cancel() => MudDialog.Close(DialogResult.Ok(ResultFactory.Canceled()));
+
+    private string TreasurerIdToName(int? id)
+        => id is null ? string.Empty : _persons.FirstOrDefault(p => p.Id == id.Value)?.Name ?? string.Empty;
 }

--- a/Data/CashRegister/CashRegisterModel.cs
+++ b/Data/CashRegister/CashRegisterModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using ClubTreasury.Data.Person;
 using ClubTreasury.Data.Transaction;
 
 namespace ClubTreasury.Data.CashRegister
@@ -12,6 +13,8 @@ namespace ClubTreasury.Data.CashRegister
         public string Name { get; set; } = string.Empty;
         [Range(1, 12)]
         public int FiscalYearStartMonth { get; set; } = 7;
+        public int? TreasurerId { get; set; }
+        public PersonModel? Treasurer { get; set; }
         [NotMapped]
         public decimal CurrentBalance => Transactions?.Sum(t => t.AccountMovement) ?? 0m;
         public ICollection<TransactionModel> Transactions { get; init; } = new List<TransactionModel>();

--- a/Data/CashRegister/CashRegisterService.cs
+++ b/Data/CashRegister/CashRegisterService.cs
@@ -40,6 +40,22 @@ namespace ClubTreasury.Data.CashRegister
             return null;
         }
 
+        public async Task<CashRegisterModel?> GetCashRegisterWithTreasurerAsync(int id, CancellationToken ct = default)
+        {
+            var cashRegister = await context.CashRegisters
+                .Include(cr => cr.Treasurer)
+                .FirstOrDefaultAsync(cr => cr.Id == id, ct);
+
+            if (cashRegister is not null)
+            {
+                logger.LogInformation("Cash register with treasurer found: {@CashRegister}", cashRegister.Name);
+                return cashRegister;
+            }
+
+            logger.LogError("Cash register not found with id '{CashRegisterId}'", id);
+            return null;
+        }
+
         public async Task<CashRegisterModel?> GetFirstCashRegisterAsync(CancellationToken ct = default)
         {
             var cashRegister = await context.CashRegisters.FirstOrDefaultAsync(ct);

--- a/Data/CashRegister/ICashRegisterService.cs
+++ b/Data/CashRegister/ICashRegisterService.cs
@@ -7,6 +7,7 @@ public interface ICashRegisterService
     Task<List<CashRegisterModel>> GetAllCashRegistersAsync(CancellationToken ct = default);
     Task<Dictionary<int, decimal>> GetCashRegisterBalancesAsync(CancellationToken ct = default);
     Task<CashRegisterModel?> GetCashRegisterByIdAsync(int id, CancellationToken ct = default);
+    Task<CashRegisterModel?> GetCashRegisterWithTreasurerAsync(int id, CancellationToken ct = default);
     Task<CashRegisterModel?> GetFirstCashRegisterAsync(CancellationToken ct = default);
     Task<Result> AddCashRegisterAsync(CashRegisterModel cashRegisterModel, CancellationToken ct = default);
     Task<Result> UpdateCashRegisterAsync(CashRegisterModel cashRegisterModel, CancellationToken ct = default);

--- a/Data/Export/Budget/ExportBudgetDialog.razor
+++ b/Data/Export/Budget/ExportBudgetDialog.razor
@@ -114,7 +114,8 @@
             var end = _model.DateRange.End!.Value.Date;
             var filename = $"{_model.FileName}_{start:yyyyMMdd}_{end:yyyyMMdd}.csv";
 
-            var result = await ExportService.ExportBudgetToCsvAsync(start, end, filename, _selectedCashRegister!.Id);
+            var options = new ExportOptions(start, end, filename, _selectedCashRegister!.Id);
+            var result = await ExportService.ExportBudgetToCsvAsync(options);
             MudDialog.Close(DialogResult.Ok(result));
         }
         catch (Exception ex)
@@ -141,7 +142,8 @@
             var end = _model.DateRange.End!.Value.Date;
             var fileName = $"{_model.FileName}_{start:yyyyMMdd}_{end:yyyyMMdd}.xlsx";
 
-            var result = await ExportService.ExportBudgetToExcelAsync(start, end, fileName, _selectedCashRegister!.Id);
+            var options = new ExportOptions(start, end, fileName, _selectedCashRegister!.Id);
+            var result = await ExportService.ExportBudgetToExcelAsync(options);
             MudDialog.Close(DialogResult.Ok(result));
         }
         catch (Exception ex)

--- a/Data/Export/ExportOptions.cs
+++ b/Data/Export/ExportOptions.cs
@@ -1,0 +1,11 @@
+namespace ClubTreasury.Data.Export;
+
+public record ExportOptions(DateTime Begin, DateTime End, string Filename, int CashRegisterId);
+
+public record PdfExportOptions(
+    DateTime Begin,
+    DateTime End,
+    string Filename,
+    int CashRegisterId,
+    string CashRegisterName,
+    string? TreasurerName) : ExportOptions(Begin, End, Filename, CashRegisterId);

--- a/Data/Export/ExportService.cs
+++ b/Data/Export/ExportService.cs
@@ -35,15 +35,14 @@ public class ExportService(
         return Path.Combine(_exportPath, sanitized);
     }
 
-    public async Task<Result> ExportTransactionsToCsvAsync(
-        DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default)
+    public async Task<Result> ExportTransactionsToCsvAsync(ExportOptions options, CancellationToken ct = default)
     {
         try
         {
             logger.LogInformation("Beginning export transactions to csv");
 
             var transactions =
-                await transactionService.GetTransactionsForExportAsync(begin, end, cashRegisterId, ct);
+                await transactionService.GetTransactionsForExportAsync(options.Begin, options.End, options.CashRegisterId, ct);
 
             var csv = new StringBuilder();
             foreach (var transaction in transactions.OrderBy(t => t.Documentnumber))
@@ -58,13 +57,13 @@ public class ExportService(
                 return operationResultFactory.ExportFailed($"{localizer["NoData"]}");
             }
 
-            var filePath = GetSafeFilePath(filename);
+            var filePath = GetSafeFilePath(options.Filename);
             await using var sw = new StreamWriter(filePath);
             await sw.WriteLineAsync(CsvHeader);
             await sw.WriteAsync(csv);
 
             logger.LogInformation("Export transactions to csv completed");
-            return operationResultFactory.ExportSuccessful(filename);
+            return operationResultFactory.ExportSuccessful(options.Filename);
         }
         catch (Exception ex)
         {
@@ -73,25 +72,28 @@ public class ExportService(
         }
     }
 
-    public async Task<Result> ExportTransactionsToPdfAsync(
-        DateTime begin, DateTime end, string filename, int cashRegisterId, string cashRegisterName, CancellationToken cancellationToken)
+    public async Task<Result> ExportTransactionsToPdfAsync(PdfExportOptions options, CancellationToken ct = default)
     {
         try
         {
             var transactions =
-                await transactionService.GetTransactionsForExportAsync(begin, end, cashRegisterId, cancellationToken);
+                await transactionService.GetTransactionsForExportAsync(options.Begin, options.End, options.CashRegisterId, ct);
 
-            var logo = await cashRegisterLogoService.GetLogoAsync(cashRegisterId, cancellationToken);
-            var filePath = GetSafeFilePath(filename);
+            var logo = await cashRegisterLogoService.GetLogoAsync(options.CashRegisterId, ct);
+            var filePath = GetSafeFilePath(options.Filename);
 
-            await transactionPdfRenderer.RenderTransactionPdfExportAsync(
-                transactions, begin, end, filePath, cashRegisterName, logo?.Data, logo?.ContentType, cancellationToken);
+            var renderRequest = new PdfRenderOptions(
+                options.Begin, options.End, filePath,
+                options.CashRegisterName, options.TreasurerName,
+                logo?.Data, logo?.ContentType);
 
-            return operationResultFactory.ExportSuccessful(filename);
+            await transactionPdfRenderer.RenderTransactionPdfExportAsync(transactions, renderRequest, ct);
+
+            return operationResultFactory.ExportSuccessful(options.Filename);
         }
         catch (OperationCanceledException)
         {
-            logger.LogWarning("PDF export canceled → {File}", filename);
+            logger.LogWarning("PDF export canceled → {File}", options.Filename);
             return operationResultFactory.Canceled();
         }
         catch (Exception ex)
@@ -101,21 +103,20 @@ public class ExportService(
         }
     }
 
-    public async Task<Result> ExportBudgetToCsvAsync(
-        DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default)
+    public async Task<Result> ExportBudgetToCsvAsync(ExportOptions options, CancellationToken ct = default)
     {
         try
         {
             var transactions =
-                await transactionService.GetTransactionsForBudgetExportAsync(begin, end, cashRegisterId, ct);
+                await transactionService.GetTransactionsForBudgetExportAsync(options.Begin, options.End, options.CashRegisterId, ct);
 
             var flat = budgetMapper.BuildFlatEntries(transactions);
             var grouped = budgetMapper.BuildBudgetHierarchy(flat);
 
-            var filePath = GetSafeFilePath(filename);
+            var filePath = GetSafeFilePath(options.Filename);
             await csvWriter.WriteAsync(filePath, grouped);
 
-            return operationResultFactory.ExportSuccessful(filename);
+            return operationResultFactory.ExportSuccessful(options.Filename);
         }
         catch (Exception ex)
         {
@@ -124,21 +125,20 @@ public class ExportService(
         }
     }
 
-    public async Task<Result> ExportBudgetToExcelAsync(
-        DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default)
+    public async Task<Result> ExportBudgetToExcelAsync(ExportOptions options, CancellationToken ct = default)
     {
         try
         {
             var transactions =
-                await transactionService.GetTransactionsForBudgetExportAsync(begin, end, cashRegisterId, ct);
+                await transactionService.GetTransactionsForBudgetExportAsync(options.Begin, options.End, options.CashRegisterId, ct);
 
             var flat = budgetMapper.BuildFlatEntries(transactions);
             var grouped = budgetMapper.BuildBudgetHierarchy(flat);
 
-            var filePath = GetSafeFilePath(filename);
-            await excelWriter.WriteAsync(filePath, grouped, begin, end);
+            var filePath = GetSafeFilePath(options.Filename);
+            await excelWriter.WriteAsync(filePath, grouped, options.Begin, options.End);
 
-            return operationResultFactory.ExportSuccessful(filename);
+            return operationResultFactory.ExportSuccessful(options.Filename);
         }
         catch (Exception ex)
         {
@@ -151,7 +151,8 @@ public class ExportService(
         DateTime begin, DateTime end, int cashRegisterId, CancellationToken ct = default)
     {
         var filename = $"Budget_{begin:yyyyMMdd}_{end:yyyyMMdd}.xlsx";
-        var result = await ExportBudgetToExcelAsync(begin, end, filename, cashRegisterId, ct);
+        var request = new ExportOptions(begin, end, filename, cashRegisterId);
+        var result = await ExportBudgetToExcelAsync(request, ct);
 
         if (result.IsFailure)
             return Array.Empty<byte>();

--- a/Data/Export/IExportService.cs
+++ b/Data/Export/IExportService.cs
@@ -4,9 +4,9 @@ namespace ClubTreasury.Data.Export;
 
 public interface IExportService
 {
-    Task<Result> ExportTransactionsToCsvAsync(DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default);
-    Task<Result> ExportTransactionsToPdfAsync(DateTime begin, DateTime end, string filename, int cashRegisterId, string cashRegisterName, CancellationToken cancellationToken);
-    Task<Result> ExportBudgetToCsvAsync(DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default);
-    Task<Result> ExportBudgetToExcelAsync(DateTime begin, DateTime end, string filename, int cashRegisterId, CancellationToken ct = default);
+    Task<Result> ExportTransactionsToCsvAsync(ExportOptions options, CancellationToken ct = default);
+    Task<Result> ExportTransactionsToPdfAsync(PdfExportOptions options, CancellationToken ct = default);
+    Task<Result> ExportBudgetToCsvAsync(ExportOptions options, CancellationToken ct = default);
+    Task<Result> ExportBudgetToExcelAsync(ExportOptions options, CancellationToken ct = default);
     Task<byte[]> ExportBudgetToExcelBytesAsync(DateTime begin, DateTime end, int cashRegisterId, CancellationToken ct = default);
 }

--- a/Data/Export/Transaction/ExportTransactionDialog.razor
+++ b/Data/Export/Transaction/ExportTransactionDialog.razor
@@ -115,7 +115,8 @@
             var end = _model.DateRange.End!.Value.Date;
             var filename = $"{_model.FileName}_{start:yyyyMMdd}_{end:yyyyMMdd}.csv";
 
-            var result = await ExportService.ExportTransactionsToCsvAsync(start, end, filename, _selectedCashRegister!.Id);
+            var options = new ExportOptions(start, end, filename, _selectedCashRegister!.Id);
+            var result = await ExportService.ExportTransactionsToCsvAsync(options);
             MudDialog.Close(DialogResult.Ok(result));
         }
         catch (Exception ex)
@@ -143,7 +144,10 @@
             var filename = $"{_model.FileName}_{start:yyyyMMdd}_{end:yyyyMMdd}.pdf";
 
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(CExportTimeOut));
-            var result = await ExportService.ExportTransactionsToPdfAsync(start, end, filename, _selectedCashRegister!.Id, _selectedCashRegister.Name, cts.Token);
+            var cashRegisterWithTreasurer = await CashRegisterService.GetCashRegisterWithTreasurerAsync(_selectedCashRegister!.Id, cts.Token);
+            var treasurerName = cashRegisterWithTreasurer?.Treasurer?.Name;
+            var options = new PdfExportOptions(start, end, filename, _selectedCashRegister.Id, _selectedCashRegister.Name, treasurerName);
+            var result = await ExportService.ExportTransactionsToPdfAsync(options, cts.Token);
             MudDialog.Close(DialogResult.Ok(result));
         }
         catch (OperationCanceledException)

--- a/Data/Export/Transaction/IPdfTransactionRenderer.cs
+++ b/Data/Export/Transaction/IPdfTransactionRenderer.cs
@@ -4,6 +4,5 @@ namespace ClubTreasury.Data.Export.Transaction;
 
 public interface IPdfTransactionRenderer
 {
-    Task RenderTransactionPdfExportAsync(IEnumerable<TransactionModel> transactions, DateTime begin, DateTime end,
-        string filePath, string cashRegisterName, byte[]? logoData, string? logoContentType, CancellationToken cancellationToken);
+    Task RenderTransactionPdfExportAsync(IEnumerable<TransactionModel> transactions, PdfRenderOptions options, CancellationToken ct = default);
 }

--- a/Data/Export/Transaction/PdfRenderOptions.cs
+++ b/Data/Export/Transaction/PdfRenderOptions.cs
@@ -1,0 +1,10 @@
+namespace ClubTreasury.Data.Export.Transaction;
+
+public record PdfRenderOptions(
+    DateTime Begin,
+    DateTime End,
+    string FilePath,
+    string CashRegisterName,
+    string? TreasurerName,
+    byte[]? LogoData,
+    string? LogoContentType);

--- a/Data/Export/Transaction/PdfTransactionRenderer.cs
+++ b/Data/Export/Transaction/PdfTransactionRenderer.cs
@@ -8,57 +8,58 @@ using ClubTreasury.Data.Transaction;
 
 namespace ClubTreasury.Data.Export.Transaction;
 
-public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStringLocalizer<Translation> localizer) : IPdfTransactionRenderer
+public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStringLocalizer<Translation> localizer) 
+    : IPdfTransactionRenderer
 {
     private const string HeaderBackgroundColor = "#DDEBF7";
     private const int DateColumnWidth = 80;
     private const int DocumentNumberColumnWidth = 60;
     private const int SumColumnWidth = 70;
     private const int AccountColumnWidth = 70;
-    public async Task RenderTransactionPdfExportAsync(IEnumerable<TransactionModel> transactions, DateTime begin, DateTime end,
-        string filePath, string cashRegisterName, byte[]? logoData, string? logoContentType, CancellationToken cancellationToken)
+    public async Task RenderTransactionPdfExportAsync(IEnumerable<TransactionModel> transactions, 
+                                                       PdfRenderOptions options, CancellationToken ct = default)
     {
         try
         {
-            logger.LogInformation("Rendering Transactions PDF → {File}", filePath);
-            var directory = Path.GetDirectoryName(filePath);
+            logger.LogInformation("Rendering Transactions PDF → {File}", options.FilePath);
+            var directory = Path.GetDirectoryName(options.FilePath);
             if (!Directory.Exists(directory))
             {
-                logger.LogError("Directory does not exist: {Directory}", Path.GetDirectoryName(filePath));
+                logger.LogError("Directory does not exist: {Directory}", Path.GetDirectoryName(options.FilePath));
                 throw new DirectoryNotFoundException($"Directory does not exist: {directory}");
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
+            ct.ThrowIfCancellationRequested();
 
             await Task.Run(() =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                RenderPdfSync(transactions, begin, end, filePath, cashRegisterName, logoData, logoContentType);
-            }, cancellationToken);
-            
-            if (!File.Exists(filePath) || new FileInfo(filePath).Length == 0)
+                ct.ThrowIfCancellationRequested();
+                RenderPdfSync(transactions, options);
+            }, ct);
+
+            if (!File.Exists(options.FilePath) || new FileInfo(options.FilePath).Length == 0)
             {
-                throw new IOException($"PDF creation failed: {filePath} is empty or does not exist");
+                throw new IOException($"PDF creation failed: {options.FilePath} is empty or does not exist");
             }
-            
-            logger.LogInformation("PDF created → {File}", filePath);
+
+            logger.LogInformation("PDF created → {File}", options.FilePath);
         }
         catch (OperationCanceledException)
         {
-            logger.LogWarning("PDF rendering canceled → {File}", filePath);
+            logger.LogWarning("PDF rendering canceled → {File}", options.FilePath);
             throw;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error occured while rendering pdf-file: {File}", filePath);
+            logger.LogError(ex, "Error occured while rendering pdf-file: {File}", options.FilePath);
             throw;
         }
     }
 
-    private void RenderPdfSync(IEnumerable<TransactionModel> transactions, DateTime begin, DateTime end, string filePath, string cashRegisterName, byte[]? logoData, string? logoContentType)
+    private void RenderPdfSync(IEnumerable<TransactionModel> transactions, PdfRenderOptions options)
     {
         var ordered = transactions.OrderBy(t => t.Documentnumber).ToList();
-        using var fs = new FileStream(filePath, FileMode.Create);
+        using var fs = new FileStream(options.FilePath, FileMode.Create);
         Document.Create(container =>
             container.Page(page =>
             {
@@ -66,8 +67,8 @@ public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStr
                 page.Size(PageSizes.A4);
                 page.PageColor(Colors.White);
                 page.DefaultTextStyle(x => x.FontSize(10).FontColor(Colors.Black));
-                page.Header().Element(lContainer => ComposeHeader(lContainer, begin, end, cashRegisterName, logoData, logoContentType));
-                page.Content().Element(c => ComposeContent(c, ordered, begin, end));
+                page.Header().Element(lContainer => ComposeHeader(lContainer, options));
+                page.Content().Element(c => ComposeContent(c, ordered, options));
                 page.Footer()
                     .AlignCenter()
                     .Text(x =>
@@ -93,30 +94,32 @@ public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStr
             .PaddingHorizontal(2);
     }
 
-    private void ComposeHeader(IContainer container, DateTime begin, DateTime end, string cashRegisterName, byte[]? logoData, string? logoContentType)
+    private void ComposeHeader(IContainer container, PdfRenderOptions options)
     {
-        var isSvg = logoContentType?.Contains("svg", StringComparison.OrdinalIgnoreCase) == true;
+        var isSvg = options.LogoContentType?.Contains("svg", StringComparison.OrdinalIgnoreCase) == true;
 
         container.Row(row =>
         {
-            if (logoData != null) RenderLogo(row.ConstantItem(100).AlignRight().Height(70), logoData, isSvg);
+            if (options.LogoData != null) RenderLogo(row.ConstantItem(100).AlignRight().Height(70), 
+                                                      options.LogoData, isSvg);
             row.RelativeItem()
                 .AlignMiddle()
                 .Column(column =>
                 {
                     column.Item()
-                        .Text(localizer["CashBook"] + " " + cashRegisterName)
+                        .Text(localizer["CashBook"] + " " + options.CashRegisterName)
                         .FontSize(20)
                         .Bold()
                         .AlignCenter();
                     column.Item()
-                        .Text($"{begin.ToString("d", CultureInfo.CurrentUICulture)} - " +
-                              $"{end.ToString("d", CultureInfo.CurrentUICulture)}")
+                        .Text($"{options.Begin.ToString("d", CultureInfo.CurrentUICulture)} - " +
+                              $"{options.End.ToString("d", CultureInfo.CurrentUICulture)}")
                         .AlignCenter();
                     column.Item().Height(5);
 
                 });
-            if (logoData != null) RenderLogo(row.ConstantItem(100).AlignLeft().Height(70), logoData, isSvg);
+            if (options.LogoData != null) RenderLogo(row.ConstantItem(100).AlignLeft().Height(70), 
+                                                      options.LogoData, isSvg);
         });
     }
 
@@ -130,7 +133,8 @@ public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStr
 
     private static string InlineSvgStyles(string svg)
     {
-        var styleMatch = Regex.Match(svg, @"<style[^>]*>\s*(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?\s*</style>", RegexOptions.Singleline);
+        var styleMatch = Regex.Match(svg, @"<style[^>]*>\s*(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?\s*</style>", 
+                                      RegexOptions.Singleline);
         if (!styleMatch.Success)
             return svg;
 
@@ -156,63 +160,84 @@ public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStr
         result = Regex.Replace(result, @"<style[^>]*>.*?</style>", "", RegexOptions.Singleline);
         return result;
     }
-    
-    private void ComposeContent(IContainer container, List<TransactionModel> ordered, DateTime begin, DateTime end)
+
+    private void ComposeContent(IContainer container, List<TransactionModel> ordered, PdfRenderOptions request)
     {
-        var headerStyle = TextStyle.Default.SemiBold();
         var culture = CultureInfo.CurrentUICulture;
 
         container.PaddingTop(5, Unit.Millimetre).Column(col =>
         {
-            col.Item().Table(table =>
+            ComposeTransactionTable(col, ordered, culture);
+            ComposeSummaryTotals(col, ordered, culture);
+            ComposeSignatureLines(col, request, culture);
+        });
+    }
+
+    private void ComposeTransactionTable(ColumnDescriptor col, List<TransactionModel> ordered, CultureInfo culture)
+    {
+        var headerStyle = TextStyle.Default.SemiBold();
+
+        col.Item().Table(table =>
+        {
+            table.ColumnsDefinition(columns =>
             {
-                table.ColumnsDefinition(columns =>
-                {
-                    columns.ConstantColumn(DateColumnWidth);
-                    columns.ConstantColumn(DocumentNumberColumnWidth);
-                    columns.RelativeColumn();
-                    columns.ConstantColumn(SumColumnWidth);
-                    columns.ConstantColumn(AccountColumnWidth);
-                });
-
-                table.Header(header =>
-                {
-                    header.Cell().Element(CellHeaderStyle).Text($"{localizer["Date"]}").Style(headerStyle).AlignCenter();
-                    header.Cell().Element(CellHeaderStyle).Text($"{localizer["DocumentNumberShort"]}").Style(headerStyle).AlignCenter();
-                    header.Cell().Element(CellHeaderStyle).Text($"{localizer["Description"]}").Style(headerStyle);
-                    header.Cell().Element(CellHeaderStyle).Text($"{localizer["Sum"]}").Style(headerStyle).AlignCenter();
-                    header.Cell().Element(CellHeaderStyle).Text($"{localizer["Account"]}").Style(headerStyle).AlignCenter();
-
-                    IContainer CellHeaderStyle(IContainer containerHeader)
-                        => DefaultCellStyle(containerHeader, HeaderBackgroundColor);
-                });
-
-                var index = 0;
-                foreach (var t in ordered)
-                {
-                    var background = GetRowBackgroundColor(index);
-
-                    table.Cell().Element(c => DefaultCellStyle(c, background)).Text(t.Date.ToString()).AlignCenter();
-                    table.Cell().Element(c => DefaultCellStyle(c, background)).Text($"B{t.Documentnumber}").AlignCenter();
-                    table.Cell().Element(c => DefaultCellStyle(c, background)).Text(t.Description);
-
-                    table.Cell().Element(c => DefaultCellStyle(c, background))
-                        .Text(t.Sum.ToString("C2", culture))
-                        .AlignRight();
-
-                    var textColor = t.AccountMovement >= 0 ? Colors.Green.Darken2 : Colors.Red.Darken2;
-
-                    table.Cell().Element(c => DefaultCellStyle(c, background))
-                        .Text(t.AccountMovement.ToString("C2", culture))
-                        .Style(TextStyle.Default.FontColor(textColor))
-                        .AlignRight();
-
-                    index++;
-                }
+                columns.ConstantColumn(DateColumnWidth);
+                columns.ConstantColumn(DocumentNumberColumnWidth);
+                columns.RelativeColumn();
+                columns.ConstantColumn(SumColumnWidth);
+                columns.ConstantColumn(AccountColumnWidth);
             });
-        
-        var totalIncome = ordered.Where(x => x.AccountMovement > 0).Sum(x => x.AccountMovement);
-        var totalExpense = ordered.Where(x => x.AccountMovement < 0).Sum(x => x.AccountMovement);
+
+            table.Header(header =>
+            {
+                header.Cell().Element(CellHeaderStyle).Text($"{localizer["Date"]}")
+                    .Style(headerStyle).AlignCenter();
+                header.Cell().Element(CellHeaderStyle).Text($"{localizer["DocumentNumberShort"]}")
+                    .Style(headerStyle).AlignCenter();
+                header.Cell().Element(CellHeaderStyle).Text($"{localizer["Description"]}")
+                    .Style(headerStyle);
+                header.Cell().Element(CellHeaderStyle).Text($"{localizer["Sum"]}")
+                    .Style(headerStyle).AlignCenter();
+                header.Cell().Element(CellHeaderStyle).Text($"{localizer["Account"]}")
+                    .Style(headerStyle).AlignCenter();
+
+                IContainer CellHeaderStyle(IContainer containerHeader)
+                    => DefaultCellStyle(containerHeader, HeaderBackgroundColor);
+            });
+
+            var index = 0;
+            foreach (var t in ordered)
+            {
+                var background = GetRowBackgroundColor(index);
+
+                table.Cell().Element(c => DefaultCellStyle(c, background)).Text(t.Date.ToString())
+                    .AlignCenter();
+                table.Cell().Element(c => DefaultCellStyle(c, background)).Text($"B{t.Documentnumber}")
+                    .AlignCenter();
+                table.Cell().Element(c => DefaultCellStyle(c, background)).Text(t.Description);
+
+                table.Cell().Element(c => DefaultCellStyle(c, background))
+                    .Text(t.Sum.ToString("C2", culture))
+                    .AlignRight();
+
+                var textColor = t.AccountMovement >= 0 ? Colors.Green.Darken2 : Colors.Red.Darken2;
+
+                table.Cell().Element(c => DefaultCellStyle(c, background))
+                    .Text(t.AccountMovement.ToString("C2", culture))
+                    .Style(TextStyle.Default.FontColor(textColor))
+                    .AlignRight();
+
+                index++;
+            }
+        });
+    }
+
+    private void ComposeSummaryTotals(ColumnDescriptor col, List<TransactionModel> ordered, CultureInfo culture)
+    {
+        var totalIncome = ordered.Where(x => x.AccountMovement > 0)
+                                        .Sum(x => x.AccountMovement);
+        var totalExpense = ordered.Where(x => x.AccountMovement < 0)
+                                         .Sum(x => x.AccountMovement);
         var balance = ordered.Sum(x => x.AccountMovement);
 
         col.Item().PaddingTop(10).Row(row =>
@@ -238,24 +263,38 @@ public class PdfTransactionRenderer(ILogger<PdfTransactionRenderer> logger, IStr
                     .AlignRight();
             });
         });
-        
+    }
+
+    private void ComposeSignatureLines(ColumnDescriptor col, PdfRenderOptions request, CultureInfo culture)
+    {
         col.Item().Row(row =>
         {
-            row.ConstantItem(100).AlignMiddle().Text($"{localizer["AccountBalance"]} {begin.ToString("d", culture)}:");
+            row.ConstantItem(100).AlignMiddle().Text($"{localizer["AccountBalance"]} " +
+                                                         $"{request.Begin.ToString("d", culture)}:");
             row.ConstantItem(100).AlignBottom().LineHorizontal(1)
                 .LineColor(Colors.Grey.Lighten1);
         });
 
         col.Item().PaddingTop(10).Row(row =>
         {
-            row.ConstantItem(100).AlignMiddle().Text($"{localizer["AccountBalance"]} {end.ToString("d", culture)}:");
+            row.ConstantItem(100).AlignMiddle().Text($"{localizer["AccountBalance"]} " +
+                                                         $"{request.End.ToString("d", culture)}:");
             row.ConstantItem(100).AlignBottom().LineHorizontal(1)
                 .LineColor(Colors.Grey.Lighten1);
         });
-    });
+
+        col.Item().PaddingTop(10).Row(row =>
+        {
+            row.ConstantItem(100).AlignMiddle().Text($"{localizer["ClubTreasurer"]}:");
+            row.ConstantItem(100).AlignBottom().Column(c =>
+            {
+                c.Item().Text(request.TreasurerName ?? string.Empty).AlignCenter();
+                c.Item().LineHorizontal(1).LineColor(Colors.Grey.Lighten1);
+            });
+        });
     }
-    
-    
+
+
     private static string GetRowBackgroundColor(int rowIndex)
     {
         return rowIndex % 2 == 0

--- a/Data/Transaction/ITransactionService.cs
+++ b/Data/Transaction/ITransactionService.cs
@@ -15,6 +15,6 @@ public interface ITransactionService
     Task<int> GetLatestDocumentNumberAsync(int registerId, CancellationToken ct = default);
 
     Task<PagedResult<TransactionModel>> GetTransactionsPagedAsync(
-        PagedRequest request,
+        PagedRequest options,
         CancellationToken cancellationToken);
 }

--- a/Migrations/20260401082940_AddTreasurerToCashRegister.Designer.cs
+++ b/Migrations/20260401082940_AddTreasurerToCashRegister.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ClubTreasury.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ClubTreasury.Migrations
 {
     [DbContext(typeof(CashDataContext))]
-    partial class CashDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260401082940_AddTreasurerToCashRegister")]
+    partial class AddTreasurerToCashRegister
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260401082940_AddTreasurerToCashRegister.cs
+++ b/Migrations/20260401082940_AddTreasurerToCashRegister.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClubTreasury.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTreasurerToCashRegister : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TreasurerId",
+                table: "CashRegisters",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CashRegisters_TreasurerId",
+                table: "CashRegisters",
+                column: "TreasurerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CashRegisters_Persons_TreasurerId",
+                table: "CashRegisters",
+                column: "TreasurerId",
+                principalTable: "Persons",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CashRegisters_Persons_TreasurerId",
+                table: "CashRegisters");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CashRegisters_TreasurerId",
+                table: "CashRegisters");
+
+            migrationBuilder.DropColumn(
+                name: "TreasurerId",
+                table: "CashRegisters");
+        }
+    }
+}

--- a/Resources/Translation.de-de.resx
+++ b/Resources/Translation.de-de.resx
@@ -1150,4 +1150,12 @@
         <value>Importieren in</value>
         <comment>ImportIn</comment>
     </data>
+    <data name="Treasurer" xml:space="preserve">
+        <value>Kassenwart</value>
+        <comment>Treasurer</comment>
+    </data>
+    <data name="ClubTreasurer" xml:space="preserve">
+        <value>Kassenwart</value>
+        <comment>ClubTreasurer</comment>
+    </data>
 </root>

--- a/Resources/Translation.en-us.resx
+++ b/Resources/Translation.en-us.resx
@@ -1151,4 +1151,12 @@
         <value>Import in</value>
         <comment>ImportIn</comment>
     </data>
+    <data name="Treasurer" xml:space="preserve">
+        <value>Treasurer</value>
+        <comment>Treasurer</comment>
+    </data>
+    <data name="ClubTreasurer" xml:space="preserve">
+        <value>Club Treasurer</value>
+        <comment>ClubTreasurer</comment>
+    </data>
 </root>

--- a/Resources/Translation.resx
+++ b/Resources/Translation.resx
@@ -1109,4 +1109,12 @@
         <value />
         <comment>ImportIn</comment>
     </data>
+    <data name="Treasurer" xml:space="preserve">
+        <value />
+        <comment>Treasurer</comment>
+    </data>
+    <data name="ClubTreasurer" xml:space="preserve">
+        <value />
+        <comment>ClubTreasurer</comment>
+    </data>
 </root>


### PR DESCRIPTION
Add TreasurerId/Treasurer navigation property to CashRegisterModel, MudSelect in dialog, PDF rendering, and parameter object refactoring (ExportOptions, PdfExportOptions, PdfRenderOptions) for ExportService.